### PR TITLE
mission_observer_comment

### DIFF
--- a/Source/MissionSystem/Private/MSMissionSystem.cpp
+++ b/Source/MissionSystem/Private/MSMissionSystem.cpp
@@ -298,6 +298,7 @@ void UMSMissionSystem::OnMissionEnded( UMSMissionData * mission_data, const bool
         CompletedMissions.Add( mission_data );
     }
 
+    // :TODO: Make sure observers of not yet started missions get cleaned up as well
     for ( auto index = MissionEndObservers.Num() - 1; index >= 0; --index )
     {
         auto & observer = MissionEndObservers[ index ];


### PR DESCRIPTION
Add comment so we don't forget to fix an issue where observers can be set without a mission being started