### PR TITLE
Call StartMission when resuming from history

### DIFF
--- a/Source/MissionSystem/Private/MSMissionSystem.cpp
+++ b/Source/MissionSystem/Private/MSMissionSystem.cpp
@@ -136,7 +136,7 @@ void UMSMissionSystem::ResumeMissionsFromHistory()
             continue;
         }
 
-        mission->Start();
+        StartMission( mission );
     }
 }
 


### PR DESCRIPTION
Call StartMission instead of mission->Start when resuming from history, to make sure the info is properly broadcasted