### PR TITLE
Completed objectives and missions

### DIFF
--- a/Source/MissionSystem/Private/ViewModels/MSMissionViewModel.cpp
+++ b/Source/MissionSystem/Private/ViewModels/MSMissionViewModel.cpp
@@ -24,9 +24,15 @@ void UMSMissionViewModel::SetObjectiveStarted( const TSubclassOf< UMSMissionObje
 
 void UMSMissionViewModel::SetObjectiveEnded( const TSubclassOf< UMSMissionObjective > & objective )
 {
-    ActiveObjectives.RemoveAll( [ & ]( auto objective_vm ) {
+    const auto predicate = [ & ]( auto objective_vm ) {
         return objective_vm->GetObjectiveClass() == objective;
-    } );
+    };
+
+    auto * objective_vm = ActiveObjectives.FindByPredicate( predicate );
+    CompletedObjectives.AddUnique( *objective_vm );
+
+    ActiveObjectives.RemoveAll( predicate );
 
     UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( ActiveObjectives );
+    UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( CompletedObjectives );
 }

--- a/Source/MissionSystem/Private/ViewModels/MSMissionViewModel.cpp
+++ b/Source/MissionSystem/Private/ViewModels/MSMissionViewModel.cpp
@@ -4,6 +4,12 @@
 #include "MSMissionData.h"
 #include "ViewModels/MSObjectiveViewModel.h"
 
+void UMSMissionViewModel::RemoveCompletedObjective( UMSObjectiveViewModel * objective_vm )
+{
+    CompletedObjectives.Remove( objective_vm );
+    UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( CompletedObjectives );
+}
+
 void UMSMissionViewModel::Initialize( UMSMission * mission )
 {
     check( mission != nullptr );
@@ -28,11 +34,13 @@ void UMSMissionViewModel::SetObjectiveEnded( const TSubclassOf< UMSMissionObject
         return objective_vm->GetObjectiveClass() == objective;
     };
 
-    auto * objective_vm = ActiveObjectives.FindByPredicate( predicate );
-    CompletedObjectives.AddUnique( *objective_vm );
+    if ( auto * objective_vm = ActiveObjectives.FindByPredicate( predicate ) )
+    {
+        CompletedObjectives.AddUnique( *objective_vm );
 
-    ActiveObjectives.RemoveAll( predicate );
+        ActiveObjectives.RemoveAll( predicate );
 
-    UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( ActiveObjectives );
-    UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( CompletedObjectives );
+        UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( ActiveObjectives );
+        UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( CompletedObjectives );
+    }
 }

--- a/Source/MissionSystem/Private/ViewModels/MSViewModel.cpp
+++ b/Source/MissionSystem/Private/ViewModels/MSViewModel.cpp
@@ -1,6 +1,14 @@
 #include "ViewModels/MSViewModel.h"
 
+#include "MSMission.h"
+#include "MSMissionData.h"
 #include "ViewModels/MSMissionViewModel.h"
+
+void UMSViewModel::RemoveCompletedMission( UMSMissionViewModel * mission_vm )
+{
+    CompletedMissions.Remove( mission_vm );
+    UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( CompletedMissions );
+}
 
 void UMSViewModel::SetMissionStarted( UMSMission * mission )
 {
@@ -9,20 +17,30 @@ void UMSViewModel::SetMissionStarted( UMSMission * mission )
         return;
     }
 
-    auto * mission_vm = NewObject< UMSMissionViewModel >( this );
-    mission_vm->Initialize( mission );
-    ActiveMissions.Add( mission_vm );
-
-    UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( ActiveMissions );
-    UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( HasActiveMissions );
+    if ( !mission->GetMissionData()->bHideOnVM )
+    {
+        auto * mission_vm = NewObject< UMSMissionViewModel >( this );
+        mission_vm->Initialize( mission );
+        ActiveMissions.Add( mission_vm );
+        UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( ActiveMissions );
+        UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( HasActiveMissions );
+    }
 }
 
 void UMSViewModel::SetMissionEnded( UMSMission * mission )
 {
-    ActiveMissions.RemoveAll( [ & ]( auto mission_vm ) {
+    const auto predicate = [ & ]( auto mission_vm ) {
         return mission_vm->GetMission() == mission;
-    } );
+    };
 
+    if ( auto * mission_vm = ActiveMissions.FindByPredicate( predicate ) )
+    {
+        CompletedMissions.AddUnique( *mission_vm );
+
+        UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( CompletedMissions );
+    }
+
+    ActiveMissions.RemoveAll( predicate );
     UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( ActiveMissions );
     UE_MVVM_BROADCAST_FIELD_VALUE_CHANGED( HasActiveMissions );
 }

--- a/Source/MissionSystem/Public/MSMissionData.h
+++ b/Source/MissionSystem/Public/MSMissionData.h
@@ -90,6 +90,10 @@ public:
     UPROPERTY( VisibleAnywhere, AdvancedDisplay )
     FGuid MissionId;
 
+    // Set to true if this objective shouldn't be added to the view model to be displayed
+    UPROPERTY( EditDefaultsOnly, meta = ( AllowPrivateAccess ) )
+    uint8 bHideOnVM : 1;
+
 #if WITH_EDITOR
     EDataValidationResult IsDataValid( FDataValidationContext & context ) const override;
 #endif

--- a/Source/MissionSystem/Public/ViewModels/MSMissionViewModel.h
+++ b/Source/MissionSystem/Public/ViewModels/MSMissionViewModel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MSObjectiveViewModel.h"
+
 #include <CoreMinimal.h>
 #include <MVVMViewModelBase.h>
 
@@ -15,6 +17,9 @@ class MISSIONSYSTEM_API UMSMissionViewModel final : public UMVVMViewModelBase
     GENERATED_BODY()
 
 public:
+    UFUNCTION( BlueprintCallable )
+    void RemoveCompletedObjective( UMSObjectiveViewModel * objective_vm );
+
     UMSMission * GetMission() const;
 
     void Initialize( UMSMission * mission );

--- a/Source/MissionSystem/Public/ViewModels/MSMissionViewModel.h
+++ b/Source/MissionSystem/Public/ViewModels/MSMissionViewModel.h
@@ -28,6 +28,9 @@ private:
     UPROPERTY( BlueprintReadOnly, FieldNotify, meta = ( AllowPrivateAccess ) )
     TArray< TObjectPtr< UMSObjectiveViewModel > > ActiveObjectives;
 
+    UPROPERTY( BlueprintReadOnly, FieldNotify, meta = ( AllowPrivateAccess ) )
+    TArray< TObjectPtr< UMSObjectiveViewModel > > CompletedObjectives;
+
     UPROPERTY( Transient )
     TObjectPtr< UMSMission > Mission;
 };

--- a/Source/MissionSystem/Public/ViewModels/MSViewModel.h
+++ b/Source/MissionSystem/Public/ViewModels/MSViewModel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MSMissionObjective.h"
+#include "MSMissionViewModel.h"
 
 #include <CoreMinimal.h>
 #include <MVVMViewModelBase.h>
@@ -16,6 +17,9 @@ class MISSIONSYSTEM_API UMSViewModel final : public UMVVMViewModelBase
     GENERATED_BODY()
 
 public:
+    UFUNCTION( BlueprintCallable )
+    void RemoveCompletedMission( UMSMissionViewModel * mission_vm );
+
     void SetMissionStarted( UMSMission * mission );
     void SetMissionEnded( UMSMission * mission );
     void SetMissionObjectiveStarted( UMSMission * mission, const TSubclassOf< UMSMissionObjective > & objective );
@@ -29,4 +33,7 @@ private:
 
     UPROPERTY( BlueprintReadOnly, FieldNotify, meta = ( AllowPrivateAccess ) )
     TArray< TObjectPtr< UMSMissionViewModel > > ActiveMissions;
+
+    UPROPERTY( BlueprintReadOnly, FieldNotify, meta = ( AllowPrivateAccess ) )
+    TArray< TObjectPtr< UMSMissionViewModel > > CompletedMissions;
 };


### PR DESCRIPTION
* Vms now keep completed missions and objectives 
* Added bool property on mission data to allow missions to not be displayed and added to Vms ( usefull for SC cinematics missions ) ( I think I should have create SC Classe  inherits from missiondata classe  and change type of sc missions data assets to be this new type but since all the VMs part will be removed from the plugin... )